### PR TITLE
Revert "Do not compare responses content_length"

### DIFF
--- a/http_shadow/backend.py
+++ b/http_shadow/backend.py
@@ -32,7 +32,7 @@ class Backend(object):
         return {
             'status_code': resp.status_code,
             'location': resp.headers.get('Location'),
-            # 'content_length': int(resp.headers.get('Content-Length')),
+            'content_length': int(resp.headers.get('Content-Length')),
             'content_type': resp.headers.get('Content-Type'),
             'surrogate_key': resp.headers.get('Surrogate-Key'),
         }


### PR DESCRIPTION
Reverts macbre/http-shadow#1

https://github.com/Wikia/app/pull/16000 - there should be no difference in `content_length` between Apache and Kubernetes now.